### PR TITLE
Python 3 compatibility 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 
 install: 
   - "pip install -r requirements.txt"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,12 @@
 from distutils.core import setup
 
 from os.path import abspath, dirname, join
-execfile(join(dirname(abspath(__file__)), 'src', 'DiffLibrary', 'version.py'))
+
+version_file = join(dirname(abspath(__file__)), 'src', 'DiffLibrary', 'version.py')
+
+with open(version_file) as filehandle:
+    code = compile(filehandle.read(), version_file, 'exec')
+    exec(code)
 
 DESCRIPTION = """
 Robot Framework keyword library that will provide keyword functionality to diff two fules together .

--- a/src/DiffLibrary/__init__.py
+++ b/src/DiffLibrary/__init__.py
@@ -1,5 +1,5 @@
 
-from keywords import DiffKeywords
+from .keywords import DiffKeywords
 
 
 class DiffLibrary(DiffKeywords):

--- a/src/DiffLibrary/compat.py
+++ b/src/DiffLibrary/compat.py
@@ -1,0 +1,3 @@
+import sys
+
+PY3 = sys.version_info > (3,)

--- a/src/DiffLibrary/keywords.py
+++ b/src/DiffLibrary/keywords.py
@@ -137,7 +137,7 @@ class DiffKeywords(object):
         # because the filter will remove the timestap diff's
         lines_to_skip = diff_lines.get(diff_func, '_getdiff')
         if lines and len(lines) > lines_to_skip:
-            print '\n'.join(lines)
+            print('\n'.join(lines))
             self.builtin.fail(
                 "differences found between %s and %s" % (actfile, reffile))
 
@@ -161,7 +161,7 @@ class DiffKeywords(object):
         else:
             try:
                 self._newdiff(file1, file2)
-            except Exception, e:
+            except Exception as e:
                 self.builtin.log(e)
 
 
@@ -212,7 +212,7 @@ class DiffKeywords(object):
         else:
             try:
                 self._newdiff(file1, file2)
-            except Exception, e:
+            except Exception as e:
                 self.builtin.log(e)
 
         os.remove(file1.name)

--- a/src/DiffLibrary/keywords.py
+++ b/src/DiffLibrary/keywords.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import tempfile
 
-
+from DiffLibrary.compat import PY3
 
 class DiffKeywords(object):
     """
@@ -181,6 +181,10 @@ class DiffKeywords(object):
 
         # it will block here and try to read everything into memory
         output = self.cmd.communicate()[0]
+
+        if PY3:
+            if isinstance(output, bytes):
+                output = output.decode(encoding='utf-8')
 
         return output, self.cmd.wait()
 


### PR DESCRIPTION
The travis-ci build completed successfully for Python 2.6, 2.7, 3.3, 3.4 and 3.5 - https://travis-ci.org/bobdoah/robotframework-difflibrary/builds/171843095
